### PR TITLE
Replacing GENIEXSecExtract::ChainWrapper with PlotUtils::ChainWrapper

### DIFF
--- a/GENIEXSecExtract/XSec.h
+++ b/GENIEXSecExtract/XSec.h
@@ -1,7 +1,7 @@
 #ifndef XSEC_H
 #define XSEC_H
 
-#include "ChainWrapper.h"
+#include "PlotUtils/ChainWrapper.h"
 
 #include <string>
 #include <vector>
@@ -92,7 +92,7 @@ public:
 
   // Does the event pass the selection to contribute to this cross
   // section? Override in your derived class
-  virtual bool passesCuts(ChainWrapper& chw, int entry)=0;
+  virtual bool passesCuts(PlotUtils::ChainWrapper& chw, int entry)=0;
 
   // Set the binning for the output histogram to be nbins equal-sized
   // bins between xmin and xmax
@@ -110,9 +110,9 @@ public:
   // Get the value of the variable that we're using for the given
   // entry in the chain(wrapper). Override this if you want to use a
   // variable that isn't defined in EVariable above
-  virtual double getVariableValue(ChainWrapper& chw, int entry);
+  virtual double getVariableValue(PlotUtils::ChainWrapper& chw, int entry);
   // If working in 2 dimensions, return a vector with both values
-  virtual std::vector<double> getVariableValues(ChainWrapper& chw, int entry);
+  virtual std::vector<double> getVariableValues(PlotUtils::ChainWrapper& chw, int entry);
 
 
   // Get the histogram of the cross section. Will be wrong if called
@@ -160,7 +160,7 @@ public:
   static Double_t NeutronMass(){ return 939.565/1e3;}//in GeV //wiki
   static Double_t MuonMass(){ return 105.65837/1e3; }//in GeV //google = wiki
 
-  static int GetProtonIndex(ChainWrapper& chw, const int entry);
+  static int GetProtonIndex(PlotUtils::ChainWrapper& chw, const int entry);
   //get theta angle wrt beam, where x, y, z in detector coordinate
   static double getTheta( double x, double y, double z );
 
@@ -168,7 +168,7 @@ public:
   static double proton_momentum_minCut(){ return   450.0;}
   static double proton_momentum_MAXCut(){ return  1200.0;}
   // Set HyperDim
-  void setHyperDim(vector< vector <double> > vec, int type){m_HyperDim = new PlotUtils::HyperDimLinearizer(vec,type);}
+  void setHyperDim(std::vector< std::vector <double> > vec, int type){m_HyperDim = new PlotUtils::HyperDimLinearizer(vec,type);}
 protected:
 
     // DC: Added 26/07/18  
@@ -181,10 +181,10 @@ protected:
 
   // Get a list of PDG codes for all the particles in the final state,
   // for entry number 'entry' in the chain(wrapper).
-  std::vector<int> getFSPDGs(ChainWrapper& chw, int entry);
+  std::vector<int> getFSPDGs(PlotUtils::ChainWrapper& chw, int entry);
 
   // Get the value of variable 'var' in entry in the chain
-  double getValue(ChainWrapper& chw, int entry, XSec::EVariable var);
+  double getValue(PlotUtils::ChainWrapper& chw, int entry, XSec::EVariable var);
 
   std::string m_name;       // Name of the cross section
   PlotUtils::MnvH1D* m_xsecHist;          // The output cross section histogram

--- a/GENIEXSecExtract/XSecLooper.h
+++ b/GENIEXSecExtract/XSecLooper.h
@@ -13,7 +13,7 @@ class MnvH2D;
 #include "TSpline.h"
 #include "TVector3.h"
 
-#include "ChainWrapper.h"
+#include "PlotUtils/ChainWrapper.h"
 #include <vector>
 #include <set>
 
@@ -143,7 +143,7 @@ public:
   void GetFSParticles( int& pionindex, int& protonid, const int entry ) const;
   bool IsMuonCollinear(const TVector3 selectedp, const int entry) const;
   bool IsScaled(const TVector3 selectedp, const TVector3 primaryproton) const;
-  static string FSIName(const int imode);
+  static std::string FSIName(const int imode);
   void PrintProton(const int fsitype, int & kprint, const int entry, const int protonindex, const int it_primary_proton) const;
   int FSIType(const int entry, const int protonindex) const;
 
@@ -222,15 +222,15 @@ protected:
   // Is the event in your fiducial volume?  If you need a
   // different fiducial volume, subclass XSecLooper and override this
   // Default is to use isFiducialTracker.
-  virtual bool isFiducial(ChainWrapper& chw, int entry);
+  virtual bool isFiducial(PlotUtils::ChainWrapper& chw, int entry);
   //=================================
   // functions for flux normalization
   //=================================
   // Is this event used for the normalization histogram?
-  virtual bool isCCRateEvent(ChainWrapper& chw, int entry);
+  virtual bool isCCRateEvent(PlotUtils::ChainWrapper& chw, int entry);
   // Is the event in the tracker fiducial volume?
   // Used for total event rate calcuclation and normalization.
-  virtual bool isFiducialTracker(ChainWrapper& chw, int entry);
+  virtual bool isFiducialTracker(PlotUtils::ChainWrapper& chw, int entry);
   // Get the total CC cross section on carbon spline from the GENIE file
   virtual TGraph* getCCSpline(int pdg);
   // Take a number of events vs Enu histogram and divide out the flux
@@ -245,12 +245,12 @@ protected:
   void divideBinsByWidth(PlotUtils::MnvH2D* h);
 
   // Are you applying any additional weight to the CV (in addition to the standard cv weight)
-  virtual double getSignalWeight(ChainWrapper & chw, int entry);
+  virtual double getSignalWeight(PlotUtils::ChainWrapper & chw, int entry);
   //Vector of weights coming from GENIE
-  std::vector<double> getGenV(ChainWrapper & chw, int entry);
+  std::vector<double> getGenV(PlotUtils::ChainWrapper & chw, int entry);
 
   std::vector<XSec*> m_xsecs; // The cross sections we're dealing with
-  ChainWrapper* m_chw;        // The ChainWrapper for the truth chain
+  PlotUtils::ChainWrapper* m_chw;        // The ChainWrapper for the truth chain
   std::map<int, PlotUtils::MnvH1D*> m_ccRateHists;      // The number of CC events on carbon histogram
   TH1D* m_fluxHist;           // The flux histogram (flux*NC12*pot)
   std::set<int> m_nuPDGs;     // PDG code(s) for the neutrino type we care about

--- a/apps/runCCIncForMultiNeutron.cpp
+++ b/apps/runCCIncForMultiNeutron.cpp
@@ -32,7 +32,7 @@ public:
     : XSec(name), m_max_E_avail(maxEAvail)
     {}
 
-  bool passesMuKinematics(ChainWrapper& chw, int entry)
+  bool passesMuKinematics(PlotUtils::ChainWrapper& chw, int entry)
   {
     ROOT::Math::AxisAngle toBeamFrame(ROOT::Math::XYZVector(1., 0., 0.), -0.05887); //NuMI beam angle in mrad from PlotUtils
     ROOT::Math::XYZVector muon(chw.GetValue("mc_primFSLepton", entry, 0), //In MeV
@@ -55,7 +55,7 @@ public:
     return true;
   }
 
-  virtual bool passesCuts(ChainWrapper& chw, int entry)
+  virtual bool passesCuts(PlotUtils::ChainWrapper& chw, int entry)
   {
     //2+ neutrons above KE threshold
     const double neutronKEThreshold = 10; //MeV

--- a/apps/runCCIncForNuEMEC.cpp
+++ b/apps/runCCIncForNuEMEC.cpp
@@ -23,7 +23,7 @@ public:
     : XSec(name),  m_intType(intType), m_carbonOnly(carbonOnly), m_PDGCode(PDGCode)
     {}
 
-  bool passesLeptonKinematics(ChainWrapper& chw, int entry)
+  bool passesLeptonKinematics(PlotUtils::ChainWrapper& chw, int entry)
   {
     //const double thetamu=chw.GetValue("truth_muon_theta", entry);
     //if(thetamu>20.*TMath::Pi()/180) return false;
@@ -35,7 +35,7 @@ public:
     return true;
   }
 
-  virtual bool passesCuts(ChainWrapper& chw, int entry)
+  virtual bool passesCuts(PlotUtils::ChainWrapper& chw, int entry)
   {
     // if ((int)chw.GetValue("mc_primaryLepton", entry) != 11)
     //   return false;
@@ -93,12 +93,12 @@ public:
       return targetNProtons==2;
     }
     default:
-      cout << "Unknown int type " << m_intType << endl;
+      std::cout << "Unknown int type " << m_intType << std::endl;
       exit(1);
     }
   }
 
- // std::vector<double> getVariableValues(ChainWrapper& chw, int entry)
+ // std::vector<double> getVariableValues(PlotUtils::ChainWrapper& chw, int entry)
  //  {
 
  //    std::vector<double> ret;
@@ -159,7 +159,7 @@ public:
     setFiducial(5980,8422);
   }
 
-  virtual double getPionWeight(ChainWrapper& chw, int entry)
+  virtual double getPionWeight(PlotUtils::ChainWrapper& chw, int entry)
   {
     if(!m_doPionWeight) return 1;
 
@@ -179,7 +179,7 @@ public:
     return rvn1piWeight*brandonWeight*cohWeight;
   }
 
-  virtual double getRPAWeight(ChainWrapper& chw, int entry)
+  virtual double getRPAWeight(PlotUtils::ChainWrapper& chw, int entry)
   {
     if(!m_doRPA) return 1;
 
@@ -217,7 +217,7 @@ public:
     return thisrwtemp;
   }
 
-  virtual double getSignalWeight(ChainWrapper& chw, int entry)
+  virtual double getSignalWeight(PlotUtils::ChainWrapper& chw, int entry)
   {
     return 1.0;//getPionWeight(chw, entry)*getRPAWeight(chw, entry);
   }

--- a/apps/runXSecLooper_CCQENuInclusive.cpp
+++ b/apps/runXSecLooper_CCQENuInclusive.cpp
@@ -17,7 +17,7 @@ public:
   {
   };
 
-bool isQELikeSignal( ChainWrapper& chw, int entry ) {
+bool isQELikeSignal( PlotUtils::ChainWrapper& chw, int entry ) {
 
   int genie_n_muons         = 0;
   int genie_n_mesons        = 0;
@@ -63,7 +63,7 @@ bool isQELikeSignal( ChainWrapper& chw, int entry ) {
 }
   // Override this method from the base class to decide what events to
   // include in this selection
-  virtual bool passesCuts(ChainWrapper& chw, int entry)
+  virtual bool passesCuts(PlotUtils::ChainWrapper& chw, int entry)
   {
     if((int)chw.GetValue("mc_incoming", entry)!=14) return false;
     if((int)chw.GetValue("mc_current", entry)!=1) return false;
@@ -96,9 +96,9 @@ void runMinModDepCCQEXSec()
   double pz_edges[] = { 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 15.0, 20.0 };
   int pz_nbins = 12;
  
-  vector<double> recoil3Dbins;
-  vector<double> pt3Dbins;
-  vector<double> pz3Dbins;
+  std::vector<double> recoil3Dbins;
+  std::vector<double> pt3Dbins;
+  std::vector<double> pz3Dbins;
 
   pt3Dbins.push_back(0.0);
   //  pt3Dbins.push_back(0.075);//added ME
@@ -124,7 +124,7 @@ void runMinModDepCCQEXSec()
   full3D.push_back(pt3Dbins);
   full3D.push_back(pz3Dbins);
 
-  cout << pt3Dbins.size() << endl;
+  std::cout << pt3Dbins.size() << std::endl;
   int pzrecoil_nbins = (recoil3Dbins.size()+1)*(pz3Dbins.size()+1);
   double pzrecoil_edges[pzrecoil_nbins];
   double pt3D_edges[7];
@@ -156,7 +156,7 @@ void runMinModDepCCQEXSec()
   loop.runLoop();
 
   // Get the output histograms and save them to file
-  string geniefilename =  "GENIEXSECEXTRACT_CCQENuInclusive_me1L.root";
+  std::string geniefilename =  "GENIEXSECEXTRACT_CCQENuInclusive_me1L.root";
   TFile fout(geniefilename.c_str(), "RECREATE");
   for(uint i=0; i<loop.getXSecs().size(); ++i){
     if(loop.getXSecs()[i]->getDimension()==1){ 

--- a/src/XSecLooper.cxx
+++ b/src/XSecLooper.cxx
@@ -1,6 +1,6 @@
 #include "GENIEXSecExtract/XSecLooper.h"
 
-#include "GENIEXSecExtract/ChainWrapper.h"
+#include "PlotUtils/ChainWrapper.h"
 #include "GENIEXSecExtract/XSec.h"
 
 #include "TH1D.h"
@@ -45,7 +45,7 @@ m_useFiducialBranch(true), m_playlist(FluxReweighter::minervame1D)
     
     //setup CV weighting infrastructure
     char *mparalocation = std::getenv("MPARAMFILESROOT");
-    string directory_data = string(mparalocation)+"/data/Reweight/";
+    std::string directory_data = std::string(mparalocation)+"/data/Reweight/";
     weight_cv_2p2h= new weight_2p2h(directory_data+"/fit-mec-2d-noScaleDown-penalty00300-best-fit");
     weight_cv_and_var_RPA = new weightRPA(directory_data+"/outNievesRPAratio-nu12C-20GeV-20170202.root");
 }
@@ -65,7 +65,7 @@ void XSecLooper::addFiles(const char* inputFileGlob)
         cout<<"XSecLooper::addFiles list: "<<inputFileGlob<<endl;
         
         int nfile=0;
-        string line;
+        std::string line;
         while( !infile.eof() ) {
             infile >> line;
             if(line==""){ continue;}
@@ -224,7 +224,7 @@ bool XSecLooper::IsScaled(const TVector3 selectedp, const TVector3 primaryproton
     return fabs(fabs(costheta)-1)<epsilon;
 }
 
-string XSecLooper::FSIName(const int imode)
+std::string XSecLooper::FSIName(const int imode)
 {
     if(imode<0){
         return "Default";


### PR DESCRIPTION
There exist 2 separate versions of the ChainWrapper class, one in GENIEXSecExtract and one in PlotUtils.
This commit replaces instances of the GENIEXSecExtract with the preferred PlotUtils version.